### PR TITLE
Fixes RT#90688 Moose enum warnings

### DIFF
--- a/lib/Yukki/Types.pm
+++ b/lib/Yukki/Types.pm
@@ -53,7 +53,7 @@ This is a valid access level. This includes any of the following values:
 
 =cut
 
-enum AccessLevel, qw( read write none );
+enum AccessLevel, [qw( read write none )];
 
 =head2 NavigationLinks
 
@@ -91,7 +91,7 @@ This is either an absolute URL or the words C<SCRIPT_NAME> or C<REWRITE>.
 
 =cut
 
-enum BaseURLEnum, qw( SCRIPT_NAME REWRITE );
+enum BaseURLEnum, [qw( SCRIPT_NAME REWRITE )];
 
 subtype BaseURL, as BaseURLEnum|Uri;
 


### PR DESCRIPTION
This fixes RT#90688: warnings produced by the change to the way enum should be called.

See https://rt.cpan.org/Ticket/Display.html?id=90688
