### PR TITLE
Fixes RT#90921 Deprecated Class::MOP::load_class

### DIFF
--- a/lib/Yukki.pm
+++ b/lib/Yukki.pm
@@ -2,6 +2,8 @@ package Yukki;
 use 5.12.1;
 use Moose;
 
+use Class::Load;
+
 use Yukki::Settings;
 use Yukki::Types qw( AccessLevel );
 use Yukki::Error qw( http_throw );
@@ -116,7 +118,7 @@ the instance constructor.
 sub model {
     my ($self, $name, $params) = @_;
     my $class_name = join '::', 'Yukki::Model', $name;
-    Class::MOP::load_class($class_name);
+    Class::Load::load_class($class_name);
     return $class_name->new(app => $self, %{ $params // {} });
 }
 

--- a/lib/Yukki/Model/File.pm
+++ b/lib/Yukki/Model/File.pm
@@ -4,6 +4,7 @@ use Moose;
 
 extends 'Yukki::Model';
 
+use Class::Load;
 use Digest::SHA1 qw( sha1_hex );
 use Number::Bytes::Human qw( format_bytes );
 use LWP::MediaTypes qw( guess_media_type );
@@ -505,7 +506,7 @@ Takes this file and returns a L<Yukki::Model::FilePreview> object, with the file
 sub file_preview {
     my ($self, %params) = @_;
 
-    Class::MOP::load_class('Yukki::Model::FilePreview');
+    Class::Load::load_class('Yukki::Model::FilePreview');
     return Yukki::Model::FilePreview->new(
         %params,
         app        => $self->app,

--- a/lib/Yukki/Web.pm
+++ b/lib/Yukki/Web.pm
@@ -3,6 +3,8 @@ use Moose;
 
 extends qw( Yukki );
 
+use Class::Load;
+
 use Yukki::Error qw( http_throw http_exception );
 use Yukki::Types qw( PluginList );
 use Yukki::Web::Context;
@@ -84,7 +86,7 @@ sub _build_plugins {
         my $class  = $module;
            $class  = "Yukki::Web::Plugin::$class" unless $class =~ s/^\+//;
 
-        Class::MOP::load_class($class);
+        Class::Load::load_class($class);
 
         push @plugins, $class->new(%$plugin_settings, app => $self);
     }
@@ -115,7 +117,7 @@ Helper method used by L</controller> and L</view>.
 sub component {
     my ($self, $type, $name) = @_;
     my $class_name = join '::', 'Yukki::Web', $type, $name;
-    Class::MOP::load_class($class_name);
+    Class::Load::load_class($class_name);
     return $class_name->new(app => $self);
 }
 


### PR DESCRIPTION
This fixes RT#90921: deprecated Class::MOP::load_class

See https://rt.cpan.org/Ticket/Display.html?id=90921
